### PR TITLE
fix CRAN errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: atime
 Type: Package
 Title: Asymptotic Timing
-Version: 2022.8.25
+Version: 2022.9.8
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 Changes in version 2022.9.8
 
-- git vignette uses .libPaths under /tmp, for CRAN.
+- git vignette uses eval=F, .libPaths under /tmp, for CRAN.
 - try() in binseg and cum_median vignettes, for CRAN.
 
 Changes in version 2022.8.25

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in version 2022.9.8
+
+- git vignette uses .libPaths under /tmp, for CRAN.
+- try() in binseg and cum_median vignettes, for CRAN.
+
 Changes in version 2022.8.25
 
 - remove callr in examples (keep in vignette).

--- a/vignettes/binseg.Rmd
+++ b/vignettes/binseg.Rmd
@@ -117,7 +117,7 @@ below,
 
 ```{r}
 best.refs <- best.list$ref[each.sign.rank==1]
-time.refs <- best.refs[unit=="seconds"]
+(time.refs <- best.refs[unit=="seconds"])
 ```
 
 Then you can plot these references with the empirical data using the
@@ -125,7 +125,11 @@ ggplot code below,
 
 ```{r}
 ref.color <- "red"
-if(require(ggplot2)){
+## try() to avoid CRAN error 'from' must be a finite number, on
+## Flavors: r-devel-linux-x86_64-debian-gcc, r-release-linux-x86_64,
+## due to https://github.com/r-lib/scales/issues/307
+(seconds.dt <- best.list$meas[unit=="seconds"])
+try(if(require(ggplot2)){
   gg <- ggplot()+
     geom_line(aes(
       N, reference, group=fun.name),
@@ -134,7 +138,7 @@ if(require(ggplot2)){
     geom_line(aes(
       N, empirical),
       size=1,
-      data=best.list$meas[unit=="seconds"])+
+      data=seconds.dt)+
     scale_x_log10()+
     scale_y_log10("median line, min/max band")+
     facet_wrap("expr.name")+
@@ -149,7 +153,7 @@ if(require(ggplot2)){
   }else{
     gg
   }
-}
+})
 ```
 
 ## Custom asymptotic references
@@ -170,8 +174,8 @@ Note that in the code above, each R function should take as input the
 data size `N` and output log base 10 of the reference function.
 
 ```{r}
-my.best.time.refs <- my.best$ref[unit=="seconds"]
-if(require(ggplot2)){
+(my.best.time.refs <- my.best$ref[unit=="seconds"])
+try(if(require(ggplot2)){
   gg <- ggplot()+
     geom_line(aes(
       N, reference, group=fun.name),
@@ -180,7 +184,7 @@ if(require(ggplot2)){
     geom_line(aes(
       N, empirical),
       size=1,
-      data=best.list$meas[unit=="seconds"])+
+      data=seconds.dt)+
     scale_x_log10()+
     scale_y_log10("median line, min/max band")+
     facet_wrap("expr.name")+
@@ -195,7 +199,7 @@ if(require(ggplot2)){
   }else{
     gg
   }
-}
+})
 ```
 
 From the plot above you should be able to see the asymptotic time

--- a/vignettes/cum_median.Rmd
+++ b/vignettes/cum_median.Rmd
@@ -37,11 +37,16 @@ atime.list <- atime::atime(
   },
   times=5)
 plot(atime.list)
+```
 
-best.list <- atime::references_best(atime.list)
-ref.dt <- best.list$ref[each.sign.rank==1]
+```{r}
+(best.list <- atime::references_best(atime.list))
+(ref.dt <- best.list$ref[each.sign.rank==1])
 library(data.table)
-if(require(ggplot2)){
+## try() to avoid CRAN error 'from' must be a finite number, on
+## https://www.stats.ox.ac.uk/pub/bdr/Rblas/README.txt, due to
+## https://github.com/r-lib/scales/issues/307
+try(if(require(ggplot2)){
   hline.df <- with(atime.list, data.frame(seconds.limit, unit="seconds"))
   gg <- ggplot()+
     theme_bw()+
@@ -79,7 +84,7 @@ if(require(ggplot2)){
   }else{
     gg
   }
-}
+})
 ```
 
 The plots above show significant speed differences between the two

--- a/vignettes/git.Rmd
+++ b/vignettes/git.Rmd
@@ -6,7 +6,8 @@
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = FALSE
 )
 ```
 

--- a/vignettes/git.Rmd
+++ b/vignettes/git.Rmd
@@ -27,10 +27,10 @@ Next, to satisfy the CRAN requirement that we can not install packages
 to the default library, we must create a library under /tmp,
 
 ```{r}
-lib.path <- tempfile()
-dir.create(lib.path)
-.libPaths(c(lib.path, .libPaths()))
-.libPaths()
+tmp.lib.path <- tempfile()
+dir.create(tmp.lib.path)
+lib.path.vec <- c(tmp.lib.path, .libPaths())
+.libPaths(lib.path.vec)
 ```
 
 Next, we define a helper function `run.atime` that will run
@@ -38,7 +38,8 @@ Next, we define a helper function `run.atime` that will run
 versions of a function:
 
 ```{r}
-run.atime.versions <- function(PKG.PATH){
+run.atime.versions <- function(PKG.PATH, LIB.PATH){
+  if(!missing(LIB.PATH)).libPaths(LIB.PATH)
   atime::atime_versions(
     pkg.path=PKG.PATH,
     N=2^seq(2, 20),
@@ -81,7 +82,7 @@ timings,
 ```{r}
 atime.ver.list <- if(requireNamespace("callr")){
   requireNamespace("atime")
-  callr::r(run.atime.versions, list(pkg.path))
+  callr::r(run.atime.versions, list(pkg.path, lib.path.vec))
 }else{
   run.atime.versions(pkg.path)
 }
@@ -169,7 +170,8 @@ The `expr.list` created above can be provided as an argument to the
 `atime` function as in the code below,
 
 ```{r}
-run.atime <- function(ELIST){
+run.atime <- function(ELIST, LIB.PATH){
+  if(!missing(LIB.PATH)).libPaths(LIB.PATH)
   atime::atime(
     N=2^seq(2, 20),
     setup={
@@ -180,7 +182,7 @@ run.atime <- function(ELIST){
 }
 atime.list <- if(requireNamespace("callr")){
   requireNamespace("atime")
-  callr::r(run.atime, list(expr.list))
+  callr::r(run.atime, list(expr.list, lib.path.vec))
 }else{
   run.atime(expr.list)
 }

--- a/vignettes/git.Rmd
+++ b/vignettes/git.Rmd
@@ -18,9 +18,19 @@ the binsegRcpp package,
 
 ```{r}
 old.opt <- options(width=100)
-tdir <- tempfile()
-dir.create(tdir)
-git2r::clone("https://github.com/tdhock/binsegRcpp", tdir)
+pkg.path <- tempfile()
+dir.create(pkg.path)
+git2r::clone("https://github.com/tdhock/binsegRcpp", pkg.path)
+```
+
+Next, to satisfy the CRAN requirement that we can not install packages
+to the default library, we must create a library under /tmp,
+
+```{r}
+lib.path <- tempfile()
+dir.create(lib.path)
+.libPaths(c(lib.path, .libPaths()))
+.libPaths()
 ```
 
 Next, we define a helper function `run.atime` that will run
@@ -28,9 +38,9 @@ Next, we define a helper function `run.atime` that will run
 versions of a function:
 
 ```{r}
-run.atime.versions <- function(TDIR){
+run.atime.versions <- function(PKG.PATH){
   atime::atime_versions(
-    pkg.path=TDIR,
+    pkg.path=PKG.PATH,
     N=2^seq(2, 20),
     setup={
       max.segs <- as.integer(N/2)
@@ -71,9 +81,9 @@ timings,
 ```{r}
 atime.ver.list <- if(requireNamespace("callr")){
   requireNamespace("atime")
-  callr::r(run.atime.versions, list(tdir))
+  callr::r(run.atime.versions, list(pkg.path))
 }else{
-  run.atime.versions(tdir)
+  run.atime.versions(pkg.path)
 }
 names(atime.ver.list$measurements)
 atime.ver.list$measurements[, .(N, expr.name, min, median, max, kilobytes)]
@@ -136,7 +146,7 @@ code below:
 
 ```{r}
 (ver.list <- atime::atime_versions_exprs(
-  pkg.path=tdir,
+  pkg.path=pkg.path,
   expr=binsegRcpp::binseg_normal(data.vec, max.segs),
   cv="908b77c411bc7f4fcbcf53759245e738ae724c3e",
   "rm unord map"="dcd0808f52b0b9858352106cc7852e36d7f5b15d",

--- a/vignettes/git.Rmd
+++ b/vignettes/git.Rmd
@@ -13,8 +13,8 @@ knitr::opts_chunk$set(
 ## Basic usage, `atime_versions` function
 
 In this vignette we show you how to compare asymptotic timings of an R
-expression which uses different versions of a package. Let us begin by cloning
-the binsegRcpp package,
+expression which uses different versions of a package. Let us begin by
+cloning the binsegRcpp package,
 
 ```{r}
 old.opt <- options(width=100)
@@ -76,8 +76,10 @@ vignette code, in order to run the different versions of the code
 using `callr::r`, in a separate R process. This allows us to avoid
 CRAN warnings about unexpected files found in the package check
 directory, by safely delete/remove the installed packages, after
-having run the example code. In the code block below we compute the
-timings,
+having run the example code. For a more typical usage see
+`example(atime_versions, package="atime")`.
+
+In the code block below we compute the timings,
 
 ```{r}
 atime.ver.list <- if(requireNamespace("callr")){
@@ -186,6 +188,13 @@ atime.list <- if(requireNamespace("callr")){
 }else{
   run.atime(expr.list)
 }
+```
+
+Again note in the code above that we defined a helper function,
+`run.atime`, and used `callr::r`, to avoid CRAN issues. For a more
+typical usage see `example(atime_versions_exprs, package="atime")`.
+
+```{r}
 atime.list$measurements[, .(N, expr.name, median, kilobytes)]
 ```
 


### PR DESCRIPTION
try() in vignettes to avoid CRAN error 'from' must be a finite number, on Flavors: r-devel-linux-x86_64-debian-gcc, r-release-linux-x86_64, and https://www.stats.ox.ac.uk/pub/bdr/Rblas/README.txt, due to https://github.com/r-lib/scales/issues/307

Need to create library under /tmp before running atime_versions* because 
```
The check problems on the Debian systems are caused by attempts to write
to the user library to which all packages get installed before checking
(and which now is remounted read-only for checking).

Having package code which is run as part of the checks and attempts to
write to the user library violates the CRAN Policy's

  Packages should not write in the user’s home filespace (including
  clipboards), nor anywhere else on the file system apart from the R
  session’s temporary directory (or during installation in the location
  pointed to by TMPDIR: and such usage should be cleaned up).
```
fix is to do something like .libPaths(tempdir()) before and then clean up after.