### PR TITLE
Replace '::' instead of ':'

### DIFF
--- a/R/versions.R
+++ b/R/versions.R
@@ -166,11 +166,12 @@ atime_versions_exprs <- function(pkg.path, expr, sha.vec=NULL, verbose=FALSE, pk
     new.Package <- new.Package.vec[[commit.i]]
     old.lines <- capture.output(substitute(expr))
     new.lines <- gsub(
-      paste0(Package,":"),
-      paste0(new.Package,":"),
-      old.lines)
+      paste0(Package,"::"),
+      paste0(new.Package,"::"),
+      old.lines,
+      fixed=TRUE)
     if(Package!=new.Package && identical(old.lines,new.lines)){
-      stop(sprintf("expr should contain at least one instance of %s: to replace with %s:", Package, new.Package))
+      stop(sprintf("expr should contain at least one instance of %s:: to replace with %s::", Package, new.Package))
     }
     a.args[[commit.name]] <- str2lang(paste(new.lines, collapse="\n"))
     atime_versions_install(


### PR DESCRIPTION
The error here was not totally clear:

https://github.com/Rdatatable/data.table/pull/6107

Since `:` alone has a few connotations in R, whereas `::` is a lot clearer. In principle there can be packages where `:` in the code winds up being the `seq()` operator, too, so using `::` should be safer as well. And `fixed=TRUE` prevents things like `dataXtable::` from being matched (not very likely, but not much harm in safety)