### PR TITLE
atime_versions() works with package in sub-dir of git repo

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,13 +50,15 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Install R Package Build Dependencies on MacOS, from https://github.com/stan-dev/cmdstanr/pull/1072/files
+        if: ${{ runner.os == 'macOS' }}
+        uses: r-hub/actions/setup-r-sysreqs@v1
+        with:
+          type: 'minimal'
+
       - name: install git2r
         shell: bash
         run: R -e 'install.packages("git2r",type="source",repos="http://cloud.r-project.org")'
-
-      - name: Install gettext so #include <libintl.h> works when compiling data.table, https://stackoverflow.com/questions/11370684 https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-macos-runners
-        shell: bash
-        run: R -e 'system("brew reinstall gettext && brew unlink gettext && brew link gettext --force")'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,9 @@ jobs:
         shell: bash
         run: R -e 'install.packages("git2r",type="source",repos="http://cloud.r-project.org")'
 
+      - name: Install gettext so #include <libintl.h> works when compiling data.table, https://stackoverflow.com/questions/11370684 https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-macos-runners
+        run: R -e 'system("brew reinstall gettext && brew unlink gettext && brew link gettext --force")'
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,7 @@ jobs:
         run: R -e 'install.packages("git2r",type="source",repos="http://cloud.r-project.org")'
 
       - name: Install gettext so #include <libintl.h> works when compiling data.table, https://stackoverflow.com/questions/11370684 https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-macos-runners
+        shell: bash
         run: R -e 'system("brew reinstall gettext && brew unlink gettext && brew link gettext --force")'
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     stringi,
     re2,
     binsegRcpp,
-    grates,
+    grates, fastymd,
     wbs,
     fpop,
     changepoint,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Suggests:
     stringi,
     re2,
     binsegRcpp,
+    grates,
     wbs,
     fpop,
     changepoint,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: atime
 Type: Package
 Title: Asymptotic Timing
-Version: 2025.4.1
+Version: 2025.4.26
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2025.4.26
+
+- atime_versions() now works for an R package in a sub-directory of a git repo (package no longer needs to be in root of git repo).
+
 Changes in version 2025.4.1
 
 - add label column to predictions table, with commas for thousands, etc.

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 Changes in version 2025.4.26
 
-- atime_versions() now works for an R package in a sub-directory of a git repo (package no longer needs to be in root of git repo).
+- atime_versions() now works for an R package in a sub-directory of a git repo (package no longer needs to be in root of git repo). Thanks @TimTaylor for the idea in issue#79. (PR#80)
+- PR#81: minor doc fixes, and use round() to avoid display of decimal places in label column of predictions table (bug introduced by PR#75).
 
 Changes in version 2025.4.1
 
-- add label column to predictions table, with commas for thousands, etc.
+- add label column to predictions table, with commas for thousands, etc. (PR#75)
 
 Changes in version 2025.1.21
 

--- a/R/versions.R
+++ b/R/versions.R
@@ -47,14 +47,16 @@ atime_versions_install <- function(Package, pkg.path, new.Package.vec, sha.vec, 
   pkgs.in.lib <- basename(dirname(DESC.in.lib))
   new.not.installed <- !new.Package.vec %in% pkgs.in.lib
   if(any(new.not.installed)){
-    tdir <- tempfile()
+    ## on GH actions windows tempfile() gives C:\Users\RUNNER~1\AppData\Local\Temp\Rtmpc9T5Us/working_dir\Rtmpu23suf\file5d41af35765
+    tdir <- normalizePath(tempfile())
     dir.create(tdir)
     ## pkg.path may be path/to/repo/pkg
-    orig.repo <- git2r::repository(pkg.path)
+    norm.pkg.path <- normalizePath(pkg.path)
+    orig.repo <- git2r::repository(norm.pkg.path)
     ## path/to/repo root without trailing /.git
-    orig.repo.path <- dirname(orig.repo$path)
+    orig.repo.path <- normalizePath(dirname(orig.repo$path))
     ## /pkg
-    pkg.suffix.in.repo <- sub(orig.repo.path, "", normalizePath(pkg.path), fixed=TRUE)
+    pkg.suffix.in.repo <- sub(orig.repo.path, "", norm.pkg.path, fixed=TRUE)
     for(new.i in which(new.not.installed)){
       sha <- sha.vec[[new.i]]
       new.Package <- new.Package.vec[[new.i]]

--- a/R/versions.R
+++ b/R/versions.R
@@ -163,6 +163,9 @@ atime_versions_exprs <- function(pkg.path, expr, sha.vec=NULL, verbose=FALSE, pk
   dots.vec <- mc.args[!names(mc.args) %in% formal.names]
   SHA.vec <- get_sha_vec(sha.vec, dots.vec)
   pkg.DESC <- file.path(pkg.path, "DESCRIPTION")
+  if(!file.exists(pkg.DESC)){
+    stop(sprintf("pkg.path=%s should be path to an R package, but %s does not exist", pkg.path, pkg.DESC))
+  }
   DESC.mat <- read.dcf(pkg.DESC)
   Package <- DESC.mat[,"Package"]
   new.Package.vec <- paste0(

--- a/R/versions.R
+++ b/R/versions.R
@@ -90,7 +90,7 @@ atime_versions_install <- function(Package, pkg.path, new.Package.vec, sha.vec, 
             "R")),
           'CMD INSTALL -l',
           shQuote(.libPaths()[1]),
-          new.pkg.path)
+          shQuote(new.pkg.path))
         status.int <- system(INSTALL.cmd)
         if(status.int != 0){
           stop(INSTALL.cmd, " returned error status code ", status.int)

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -12,7 +12,7 @@ atime_versions(
  ...)
 }
 \arguments{
-  \item{pkg.path}{Path to git repo containing R package.}
+  \item{pkg.path}{Path to R package in a git repo.}
   \item{N}{numeric vector of data sizes to vary.}
   \item{setup}{
     expression to evaluate for every data size, before timings.
@@ -83,6 +83,19 @@ if(FALSE){
   plot(atime.list)
 
   atime::atime_versions_remove("binsegRcpp")
+
+  gdir <- tempfile()
+  dir.create(gdir)
+  git2r::clone("https://github.com/tdhock/grates", gdir)
+  glist <- atime::atime_versions(
+    file.path(gdir,"pkg"),
+    current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",
+    old     = "51056b9c4363797023da4572bde07e345ce57d9c",
+    setup   = date_vec <- rep(Sys.Date(), N),
+    expr    = grates::as_yearmonth(date_vec))
+  plot(glist)
+
+  atime::atime_versions_remove("grates")
 
 }
 

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -130,3 +130,12 @@ test_that("atime_versions works with grates pkg in sub-dir of git repo", {
     expr    = grates::as_yearmonth(date_vec))
   expect_is(glist, "atime")
 })
+
+test_that("atime_pkg_test_info() works for data.table, run one test case", {
+  dt_dir <- tempfile()
+  dir.create(dt_dir)
+  git2r::clone("https://github.com/Rdatatable/data.table", dt_dir)
+  dt_info <- atime::atime_pkg_test_info(dt_dir)
+  dt_result <- eval(dt_info$test.call[[1]])
+  expect_is(dt_result, "atime")
+})

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -104,3 +104,28 @@ test_that("pkg.edit.fun is a function", {
   e.res <- eval(test.env$test.call[["global_var_in_setup"]])
   expect_is(e.res, "atime")
 })
+
+gdir <- tempfile()
+dir.create(gdir)
+git2r::clone("https://github.com/tdhock/grates", gdir)
+
+test_that("informative error when pkg.path is not a package", {
+  expect_error({
+    atime::atime_versions(
+      gdir,
+      current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",
+      old     = "51056b9c4363797023da4572bde07e345ce57d9c",
+      setup   = date_vec <- rep(Sys.Date(), N),
+      expr    = grates::as_yearmonth(date_vec))
+  }, "pkg.path should be path to an R package, but pkg.path/DESCRIPTION does not exist")
+})
+
+test_that("atime_versions works with grates pkg in sub-dir of git repo", {
+  glist <- atime::atime_versions(
+    file.path(gdir,"pkg"),
+    current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",
+    old     = "51056b9c4363797023da4572bde07e345ce57d9c",
+    setup   = date_vec <- rep(Sys.Date(), N),
+    expr    = grates::as_yearmonth(date_vec))
+  expect_is(glist, "atime")
+})

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -121,6 +121,7 @@ test_that("informative error when pkg.path is not a package", {
 })
 
 test_that("atime_versions works with grates pkg in sub-dir of git repo", {
+  install.packages("fastymd")
   glist <- atime::atime_versions(
     file.path(gdir,"pkg"),
     current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -117,7 +117,7 @@ test_that("informative error when pkg.path is not a package", {
       old     = "51056b9c4363797023da4572bde07e345ce57d9c",
       setup   = date_vec <- rep(Sys.Date(), N),
       expr    = grates::as_yearmonth(date_vec))
-  }, "pkg.path should be path to an R package, but pkg.path/DESCRIPTION does not exist")
+  }, sprintf("pkg.path=%s should be path to an R package, but %s/DESCRIPTION does not exist", gdir, gdir), fixed=TRUE)
 })
 
 test_that("atime_versions works with grates pkg in sub-dir of git repo", {

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -121,7 +121,7 @@ test_that("informative error when pkg.path is not a package", {
 })
 
 test_that("atime_versions works with grates pkg in sub-dir of git repo", {
-  install.packages("fastymd")
+  if(!requireNamespace("fastymd"))install.packages("fastymd")
   glist <- atime::atime_versions(
     file.path(gdir,"pkg"),
     current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",


### PR DESCRIPTION
Closes #79 

example code:
```r
remotes::install_github("tdhock/atime@pkg-subdir")
gdir <- tempfile()
dir.create(gdir)
git2r::clone("https://github.com/tdhock/grates", gdir)
glist <- atime::atime_versions(
  file.path(gdir,"pkg"),
  current = "1aae646888dcedb128c9076d9bd53fcb4075dcda",
  old     = "51056b9c4363797023da4572bde07e345ce57d9c",
  setup   = date_vec <- rep(Sys.Date(), N),
  expr    = grates::as_yearmonth(date_vec))
plot(glist)
```

I see this result 
![image](https://github.com/user-attachments/assets/2e6e25ba-65ba-4503-b60e-87be2d3ac749)

@timtaylor please review. does it work for you too?