### PR TITLE
doc + predict N clarifications

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -53,7 +53,7 @@ predict.references_best <- function(object, ...){
   , label := paste0(
     expr.name,
     "\nN=",
-    format(N, big.mark=",", scientific=FALSE, trim=TRUE)
+    format(round(N), big.mark=",", scientific=FALSE, trim=TRUE)
   )][]
   class(object) <- c("atime_prediction", class(object))
   object

--- a/man/atime.Rd
+++ b/man/atime.Rd
@@ -5,8 +5,8 @@
   several different data sizes.}
 
 \usage{atime(
-N, setup, expr.list=NULL, times=10, seconds.limit=0.01, verbose=FALSE,
-result=FALSE, N.env.parent=NULL, ...)}
+ N, setup, expr.list=NULL, times=10, seconds.limit=0.01, verbose=FALSE,
+ result=FALSE, N.env.parent=NULL, ...)}
 
 \arguments{
   \item{N}{numeric vector of at least two unique data sizes, default is \code{2^seq(2,20)}.}

--- a/man/atime_pkg.Rd
+++ b/man/atime_pkg.Rd
@@ -73,16 +73,27 @@ atime_pkg_test_info(pkg.path=".", tests.dir=NULL)
 
 if(FALSE){
 
+  ## Clone binsegRcpp, and checkout a branch which has performance tests.
   tdir <- tempfile()
   dir.create(tdir)
   git2r::clone("https://github.com/tdhock/binsegRcpp", tdir)
   repo <- git2r::repository(tdir)
   git2r::checkout(repo, "another-branch")
+
+  ## Run one test.
+  info.env <- atime::atime_pkg_test_info(tdir)
+  test_name <- "binseg(1:N,maxSegs=N/2) DIST=l1"
+  (one.call <- info.env$test.call[[test_name]])
+  one.result <- eval(one.call)
+  plot(one.result) # constant difference for small N should be visible.
+
+  ## Run all tests.
   result.list <- atime::atime_pkg(tdir)
   inst.atime <- file.path(tdir, "inst", "atime")
   dir(inst.atime)
   tests.RData <- file.path(inst.atime, "tests.RData")
   (objs <- load(tests.RData))
+  plot(pkg.results[[test_name]]) # should look similar.
 
   atime::atime_versions_remove("binsegRcpp")
 

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -71,7 +71,6 @@ if(FALSE){
   git2r::clone("https://github.com/tdhock/binsegRcpp", tdir)
   atime.list <- atime::atime_versions(
     pkg.path=tdir,
-    N=2^seq(2, 20),
     setup={
       max.segs <- as.integer(N/2)
       data.vec <- 1:N
@@ -79,7 +78,7 @@ if(FALSE){
     expr=binsegRcpp::binseg_normal(data.vec, max.segs),
     cv="908b77c411bc7f4fcbcf53759245e738ae724c3e",
     "rm unord map"="dcd0808f52b0b9858352106cc7852e36d7f5b15d",
-    "mvl_construct"="5942af606641428315b0e63c7da331c4cd44c091")      
+    mvl_construct="5942af606641428315b0e63c7da331c4cd44c091")
   plot(atime.list)
 
   atime::atime_versions_remove("binsegRcpp")

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -17,14 +17,14 @@ atime_versions(
   \item{setup}{
     expression to evaluate for every data size, before timings.
     In contrast to \code{expr},
-    no replacement of \code{Package:} is performed.
+    no replacement of \code{Package::} is performed.
   }
   \item{expr}{
     code with package double-colon prefix, for example
     \code{PKG::fun(argA, argB)}, where PKG is the name of the
     package specified by \code{pkg.path}. This code will be
     evaluated for each different package version, by replacing
-    \code{PKG:} by \code{PKG.SHA:}.
+    \code{PKG::} by \code{PKG.SHA::}.
     To run different versions of implicitly-called functions
     like \code{DT[i,j]}, you need
     to call them explicitly, as in 
@@ -38,7 +38,7 @@ atime_versions(
   \item{pkg.edit.fun}{function called to edit package before
     installation, should typically replace instances of PKG with
     PKG.SHA, default works with Rcpp packages.}
-  \item{result}{logical, save results? (default FALSE)}
+  \item{result}{logical or function, passed to \code{\link{atime}}.}
   \item{N.env.parent}{environment to use as parent of environment
   created for each data size N, or NULL to use default parent env.}
   \item{\dots}{named versions.}

--- a/man/atime_versions_exprs.Rd
+++ b/man/atime_versions_exprs.Rd
@@ -7,9 +7,9 @@
   \code{atime_versions_exprs} is more flexible for the case of comparing
   different versions of one expression to another expression.}
 \usage{atime_versions_exprs(
-pkg.path, expr, sha.vec=NULL,
-verbose=FALSE,
-pkg.edit.fun=pkg.edit.default, ...)}
+ pkg.path, expr, sha.vec=NULL,
+ verbose=FALSE,
+ pkg.edit.fun=pkg.edit.default, ...)}
 \arguments{
   \item{pkg.path}{Path to git repo containing R package.}
   \item{expr}{
@@ -17,7 +17,7 @@ pkg.edit.fun=pkg.edit.default, ...)}
     \code{PKG::fun(argA, argB)}, where PKG is the name of the
     package specified by \code{pkg.path}. This code will be
     evaluated for each different package version, by replacing
-    \code{PKG:} by \code{PKG.SHA:}.
+    \code{PKG::} by \code{PKG.SHA::}.
     To run different versions of implicitly-called functions
     like \code{DT[i,j]}, you need
     to call them explicitly, as in 
@@ -35,7 +35,8 @@ pkg.edit.fun=pkg.edit.default, ...)}
 \details{
   For convenience, versions can
   be specified either as code (\dots), data (\code{sha.vec}), or both.
-  Each version should be either \code{""} (to install most recent
+  Each version should be either \code{""} (to use currently installed
+  version of package, or if missing, install most recent
   version from CRAN) or a SHA1 hash, which is passed as branch
   arg to \code{git2r::checkout}; version names used to identify/interpret
   the output/plots.
@@ -45,10 +46,12 @@ pkg.edit.fun=pkg.edit.default, ...)}
 }
 \value{
   A list of expressions, one for
-  each version, created by replacing \code{PKG:}
-  in \code{expr} with \code{PKG.SHA:}, 
+  each version, created by replacing \code{PKG::}
+  in \code{expr} with \code{PKG.SHA::}.
+  This list can be used as \code{expr.list} argument of \code{atime()},
+  instead of writing code like
   \code{atime(name1=Package.SHA1::fun(argA, argB),
-    name2=Package.SHA2::fun(argA,argB))}.
+    name2=Package.SHA2::fun(argA, argB))}.
 }
 
 \author{Toby Dylan Hocking}

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -495,7 +495,7 @@ if(require(Matrix))test_that("atime_grid parameters attribute", {
   expect_in(expected.names, names(mult.pred$prediction))
 })
 
-if(require(Matrix))test_that("result=fun works", {
+if(require(Matrix))test_that("result=fun works, N=commas no decimals", {
   pred.len <- 32^2
   sqrt.len <- sqrt(pred.len)
   vec.mat.result <- atime::atime(
@@ -507,12 +507,22 @@ if(require(Matrix))test_that("result=fun works", {
     seconds.limit=Inf)
   expect_is(vec.mat.result$measurements$length, "integer")
   vec.mat.refs <- atime::references_best(vec.mat.result)
+  ## precise estimation of length with comma for thousands:
   vec.mat.pred <- predict(vec.mat.refs, length=pred.len)
-  ## precise estimation of length:
   expect_equal(vec.mat.pred$prediction, data.table(
     unit="length",
     expr.name=c("vector","matrix","Matrix"),
     unit.value=pred.len,
     N=c(pred.len,sqrt.len,sqrt.len),
     label=c("vector\nN=1,024", "matrix\nN=32", "Matrix\nN=32")))
+  ## rounded:
+  r.len <- 10
+  r.sqrt <- sqrt(r.len)
+  round.pred <- predict(vec.mat.refs, length=r.len)
+  expect_equal(round.pred$prediction, data.table(
+    unit="length",
+    expr.name=c("vector","matrix","Matrix"),
+    unit.value=r.len,
+    N=c(r.len, r.sqrt, r.sqrt),
+    label=c("vector\nN=10", "matrix\nN=3", "Matrix\nN=3")))
 })


### PR DESCRIPTION
https://github.com/tdhock/atime/pull/75 changed how N is displayed in predict plots: commas were added for thousands, millions, etc.

Now ?atime::references_best is giving decimals in N, as in the figure below
![image](https://github.com/user-attachments/assets/02ad86ed-d87a-4440-ab89-a6412e79eb23)

Decimals should be removed.