### PR TITLE
add caching during package installation

### DIFF
--- a/R/caching.R
+++ b/R/caching.R
@@ -1,0 +1,37 @@
+setup_cache <- function(cache_root, verbose) {
+  if (is.null(cache_root)) {
+    if (!requireNamespace("rappdirs", quietly = TRUE)) {
+      install.packages("rappdirs")
+    }
+    cache_root <- rappdirs::user_cache_dir("atime_installed_pkgs", "atime")
+  }
+  dir.create(cache_root, showWarnings = FALSE, recursive = TRUE)
+  if (verbose) message("Using cache directory: ", cache_root)
+  cache_root
+}
+
+try_cache_restore <- function(target, cache, verbose) {
+  marker <- file.path(cache, "_ATIME_INSTALL_SUCCESSFUL")
+  if (!file.exists(marker)) return(FALSE)
+  
+  if (verbose) message("Restoring from cache: ", basename(cache))
+  unlink(target, recursive = TRUE, force = TRUE)
+  dir.create(target, recursive = TRUE)
+  
+  files <- list.files(cache, all.files = TRUE, no.. = TRUE)
+  if (length(files) == 0) return(FALSE)
+  
+  success <- all(file.copy(file.path(cache, files), target, recursive = TRUE))
+  success && file.exists(file.path(target, "DESCRIPTION"))
+}
+
+update_cache <- function(source, cache, verbose) {
+  if (verbose) message("Updating cache: ", basename(cache))
+  unlink(cache, recursive = TRUE, force = TRUE)
+  dir.create(cache, recursive = TRUE)
+  files <- list.files(source, all.files = TRUE, no.. = TRUE)
+  if (length(files) == 0) return()
+  file.copy(file.path(source, files), cache, recursive = TRUE)
+  # this marker is to ensure the previous steps succeeded
+  writeLines(as.character(Sys.time()), file.path(cache, "_ATIME_INSTALL_SUCCESSFUL"))
+}


### PR DESCRIPTION
summary of changes:
- added a couple of helper functions for `atime_versions_install` to make it more readable
- the atime_versions_install function has been updated to first attempt to restore a package from the cache, if not present then proceed with building the package and populating the cache with the newly built version
- using the default cache location as suggested by rappdirs
- the `atime_versions_install` function also supports an installed_cache_root argument for specifying a custom cache location

I also setup a local testing script, and on running the atime tests on data.table, the first run took about 6-7 mins and subsequent runs were around 1-1.5 mins. The total cache size before compression is 103MB for all the current data.table atime tests (comes to about 27MB on compressing with xz) well under the 500MB limit we have in the free tier, even before any of the package minification.

my next goal would be to work on the github actions side uploading/downloading this cache folder

cc @tdhock @Anirban166 