### PR TITLE
take CRAN version from installed

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -284,14 +284,14 @@ atime_pkg_test_info <- function(pkg.path=".", tests.dir=NULL){
   pkg.DESC <- file.path(pkg.path, "DESCRIPTION")
   DESC.mat <- read.dcf(pkg.DESC)
   Package <- DESC.mat[,"Package"]
-  ap <- utils::available.packages()
   repo <- git2r::repository(pkg.path)
   HEAD.commit <- git2r::revparse_single(repo, "HEAD")
   sha.vec <- c()
   HEAD.name <- paste0("HEAD=",git2r::repository_head(repo)$name)
   sha.vec[[HEAD.name]] <- git2r::sha(HEAD.commit)
-  if(Package %in% rownames(ap)){
-    CRAN.name <- paste0("CRAN=",ap[Package,"Version"])
+  installed_version <- tryCatch(packageVersion(Package), error=function(e)NULL)
+  if(!is.null(installed_version)){
+    CRAN.name <- paste0("CRAN=", installed_version)
     sha.vec[[CRAN.name]] <- ""
   }else{
     CRAN.name <- NA_character_


### PR DESCRIPTION
installed version is used for "CRAN" display version, but the installed version could be different from CRAN.