### PR TITLE
Remove bench dependency to fix setup re-run issue (#95)

### DIFF
--- a/tests/testthat/test-reference-modification.R
+++ b/tests/testthat/test-reference-modification.R
@@ -1,31 +1,10 @@
-test_that("setup runs before each timing iteration for reference modifications", {
-  skip_if_not_installed("data.table")
-  library(data.table)
-  N <- 1000
-  iterations <- 5
-  cat("\n=== Issue #95: bench::mark limitation ===\n")
-  cat("Setup runs ONCE (current behavior):\n")
-  DT <- data.table(x = sample(N), y = rnorm(N))
-  times_once <- numeric(iterations)
-  for (i in 1:iterations) {
-    start <- Sys.time()
-    setkey(DT, x)
-    times_once[i] <- as.numeric(Sys.time() - start, units = "secs")
-  }
-  cat(sprintf("  Iteration 1: %.2f ms (actual sort)\n", times_once[1] * 1000))
-  cat(sprintf("  Iterations 2-5 median: %.2f ms (just verification)\n", median(times_once[-1]) * 1000))
-  cat("\nSetup runs EACH time (desired behavior):\n")
-  times_each <- numeric(iterations)
-  for (i in 1:iterations) {
-    DT <- data.table(x = sample(N), y = rnorm(N))
-    start <- Sys.time()
-    setkey(DT, x)
-    times_each[i] <- as.numeric(Sys.time() - start, units = "secs")
-  }
-  cat(sprintf("  All iterations median: %.2f ms (consistent sorting)\n", median(times_each) * 1000))
-  ratio <- times_once[1] / median(times_once[-1])
-  cat(sprintf("Discrepancy: First iteration is %.1fx slower than rest\n", ratio))
-  expect_gt(ratio, 3, label = sprintf("Issue #95 confirmed: bench::mark does not re-run setup (ratio=%.1f)", ratio))
-  cv <- sd(times_each) / mean(times_each)
-  expect_lt(cv, 0.5, label = sprintf("When setup runs each time, timings are consistent (CV=%.3f)", cv))
+test_that("setup runs before each timing iteration", {
+  count_list <- list(setup = 0, expr = 0)
+  result <- atime::atime(
+    N = 2^(1:5),
+    setup = count_list$setup <<- count_list$setup + 1,
+    myexpr = count_list$expr <<- count_list$expr + 1
+  )
+  expect_equal(count_list$setup, count_list$expr,
+    info = "Issue #95: setup should run before each expr execution")
 })

--- a/tests/testthat/test-reference-modification.R
+++ b/tests/testthat/test-reference-modification.R
@@ -1,0 +1,31 @@
+test_that("setup runs before each timing iteration for reference modifications", {
+  skip_if_not_installed("data.table")
+  library(data.table)
+  N <- 1000
+  iterations <- 5
+  cat("\n=== Issue #95: bench::mark limitation ===\n")
+  cat("Setup runs ONCE (current behavior):\n")
+  DT <- data.table(x = sample(N), y = rnorm(N))
+  times_once <- numeric(iterations)
+  for (i in 1:iterations) {
+    start <- Sys.time()
+    setkey(DT, x)
+    times_once[i] <- as.numeric(Sys.time() - start, units = "secs")
+  }
+  cat(sprintf("  Iteration 1: %.2f ms (actual sort)\n", times_once[1] * 1000))
+  cat(sprintf("  Iterations 2-5 median: %.2f ms (just verification)\n", median(times_once[-1]) * 1000))
+  cat("\nSetup runs EACH time (desired behavior):\n")
+  times_each <- numeric(iterations)
+  for (i in 1:iterations) {
+    DT <- data.table(x = sample(N), y = rnorm(N))
+    start <- Sys.time()
+    setkey(DT, x)
+    times_each[i] <- as.numeric(Sys.time() - start, units = "secs")
+  }
+  cat(sprintf("  All iterations median: %.2f ms (consistent sorting)\n", median(times_each) * 1000))
+  ratio <- times_once[1] / median(times_once[-1])
+  cat(sprintf("Discrepancy: First iteration is %.1fx slower than rest\n", ratio))
+  expect_gt(ratio, 3, label = sprintf("Issue #95 confirmed: bench::mark does not re-run setup (ratio=%.1f)", ratio))
+  cv <- sd(times_each) / mean(times_each)
+  expect_lt(cv, 0.5, label = sprintf("When setup runs each time, timings are consistent (CV=%.3f)", cv))
+})


### PR DESCRIPTION
Test demonstrates Issue #95: bench::mark does not re-run setup between iterations, causing incorrect timings for reference-modifying functions like data.table::setkey().

Shows 9.8x discrepancy between first iteration (actual sort) and subsequent iterations (just verification). Documents current behavior.

<img width="3072" height="1840" alt="Screenshot From 2025-10-28 20-44-45" src="https://github.com/user-attachments/assets/b4ac8c1e-80e5-4fce-b290-2fe360debea3" />
