### PR TITLE
each test can have different units

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: atime
 Type: Package
 Title: Asymptotic Timing
-Version: 2026.4.2
+Version: 2026.5.29
 Depends: R (>= 3.5.0)
 Authors@R: c(
     person("Toby", "Hocking",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2026.5.29
+
+- atime_pkg() now uses only a common subset of columns of the measurements table from each test, so that each test can have different units to analyze.
+
 Changes in version 2026.4.2
 
 - atime_pkg() now sorts tests in facet plots to emphasize speedups, in addition to slowdowns. New pred.Nx used instead of N.factor (issue109 data and fix), as well as alternative="two.sided" instead of "greater" in t.test().

--- a/R/references.R
+++ b/R/references.R
@@ -80,9 +80,9 @@ references_best <- function(L, fun.list=NULL){
         references(N, .SD[[col.name]], lower.limit, fun.list),
         by=c(L$by.vec)]
       all.refs[, rank := rank(-N), by=c(L$by.vec, "fun.name")]
-      second <- all.refs[rank==2]
-      second[, dist := log10(empirical/reference) ]
-      second[, sign := sign(dist)]
+      second <- all.refs[rank==2][
+      , dist := log10(empirical/reference)
+      ][, sign := sign(dist)][]
       l.cols <- list(overall=L$by.vec, each.sign=c(L$by.vec,"sign"))
       for(best.type in names(l.cols)){
         by <- l.cols[[best.type]]

--- a/R/test.R
+++ b/R/test.R
@@ -112,19 +112,19 @@ atime_pkg_plot_files <- function(out.dir, test.info, pkg.results){
     log10.n.factor <- log10(n.factor)
     abs.log10.n.factor <- abs(log10.n.factor)
     max.N.times <- (10^abs.log10.n.factor)*sign(log10.n.factor)
+    some.meas <- best.list$meas[, .(
+      unit, expr.name, N, empirical,
+      q25, q75,
+      fun.name, fun.latex,
+      expr.class, expr.latex)]
     bench.dt.list[[Test]] <- data.table(
       Test, p.value, n.factor,
       log10.n.factor, abs.log10.n.factor,
-      max.N.times,
-      best.list$meas[, .(
-        unit, expr.name, N, empirical,
-        q25, q75,
-        fun.name, fun.latex,
-        expr.class, expr.latex)])
+      max.N.times, some.meas)
     log10.range <- range(log10(atime.list$meas$N))
     expand <- diff(log10.range)*test.info$expand.prop
     xmax <- 10^(log10.range[2]+expand)
-    blank.dt.list[[Test]] <- data.table(Test, best.list$meas[1])[, N := xmax]
+    blank.dt.list[[Test]] <- data.table(Test, some.meas[1][, N := xmax])
     gg <- ggplot2::ggplot()+
       ggplot2::ggtitle(Test)+
       ggplot2::theme_bw()+

--- a/R/test.R
+++ b/R/test.R
@@ -116,7 +116,11 @@ atime_pkg_plot_files <- function(out.dir, test.info, pkg.results){
       Test, p.value, n.factor,
       log10.n.factor, abs.log10.n.factor,
       max.N.times,
-      best.list$meas)
+      best.list$meas[, .(
+        unit, expr.name, N, empirical,
+        q25, q75,
+        fun.name, fun.latex,
+        expr.class, expr.latex)])
     log10.range <- range(log10(atime.list$meas$N))
     expand <- diff(log10.range)*test.info$expand.prop
     xmax <- 10^(log10.range[2]+expand)

--- a/inst/example_tests.R
+++ b/inst/example_tests.R
@@ -35,7 +35,8 @@ gvar <- 5
 test.list <- atime::atime_test_list(
   pkg.edit.fun=edit.data.table,
   N=c(9,90),
-  test_N_expr=atime::atime_test(N=c(2,20), expr=rnorm(N)),
-  test_expr=atime::atime_test(expr=rnorm(N)),
-  global_var_in_setup=atime::atime_test(setup=rnorm(gvar), expr=atime:::.packageName)
+  test_N_expr=atime::atime_test(N=c(2,20), expr=atime:::.packageName),
+  test_expr=atime::atime_test(expr=atime:::.packageName),
+  global_var_in_setup=atime::atime_test(setup=rnorm(gvar), expr=atime:::.packageName),
+  unit=atime::atime_test(expr=data.frame(count=1, name=atime:::.packageName), result=TRUE)
 )

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -137,13 +137,15 @@ test_that("pkg.edit.fun is a function", {
   test_N_expr <- test.env$test.list$test_N_expr
   expect_identical(test_N_expr$pkg.edit.fun, test.env$edit.data.table)
   expect_identical(test_N_expr$N, c(2,20))
-  expect_identical(test_N_expr$expr, quote(rnorm(N)))
+  expect_identical(test_N_expr$expr, quote(atime:::.packageName))
   test_expr <- test.env$test.list$test_expr
   expect_identical(test_expr$pkg.edit.fun, test.env$edit.data.table)
   expect_identical(test_expr$N, c(9,90))
-  expect_identical(test_expr$expr, quote(rnorm(N)))
+  expect_identical(test_expr$expr, quote(atime:::.packageName))
   e.res <- eval(test.env$test.call[["global_var_in_setup"]])
   expect_is(e.res, "atime")
+  p.res <- atime::atime_pkg(pkg.dir)
+  expect_is(p.res, "list")
 })
 
 gdir <- tempfile()


### PR DESCRIPTION
current error is
```r
> p.res <- atime::atime_pkg(pkg.dir)
Error in rbindlist(bench.dt.list) : 
  Item 4 has 31 columns, inconsistent with item 1 which has 29 columns. To fill missing columns use fill=TRUE.
> traceback()
3: rbindlist(bench.dt.list)
2: atime_pkg_plot_files(dirname(test.info$tests.R), test.info, pkg.results)
1: atime::atime_pkg(pkg.dir)
```
`bench.dt.list` contains `references_best(…)$measurements` for different test cases.
each is a long data table, fix should be that columns need to be uniform, even when there are different units.