### PR TITLE
edit PACKAGE arg

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Changes in version 2026.5.29
 
 - atime_pkg() now uses only a common subset of columns of the measurements table from each test, so that each test can have different units to analyze.
 - atime_versions() runs setup using the HEAD commit (if present).
+- atime_versions() bugfix for Rcpp packages, which must useDynLib(pkg) in NAMESPACE without .registration=TRUE, so we can edit PACKAGE args in R/RcppExports.R.
 
 Changes in version 2026.4.2
 

--- a/R/test.R
+++ b/R/test.R
@@ -24,7 +24,7 @@ atime_pkg <- function(pkg.path=".", tests.dir=NULL){
 
 atime_pkg_plot_files <- function(out.dir, test.info, pkg.results){
   each.sign.rank <- unit <- . <- N <- expr.name <- reference <- fun.name <- 
-    empirical <- q25 <- q75 <- p.str <- p.value <- P.value <- 
+    empirical <- q25 <- q75 <- p.str <- p.value <- P.value <- fun.latex <- expr.class <- expr.latex <- 
       seconds.limit <- time <- log10.seconds <- seconds <- Test <-
         N.factor <- unit.value <- x.str <- pred.Nx <- NULL
   ## above to avoid CRAN check NOTE.

--- a/R/versions.R
+++ b/R/versions.R
@@ -3,7 +3,11 @@ glob_find_replace <- function(glob, FIND, REPLACE){
   for(f in some.files){
     l.old <- readLines(f)
     l.new <- gsub(FIND, REPLACE, l.old)
-    writeLines(l.new, f)
+    if(identical(l.old, l.new)){
+      warning(sprintf("no changes to %s when FIND=%s and replace=%s", f, FIND, REPLACE))
+    }else{
+      writeLines(l.new, f)
+    }
   }
 }
 
@@ -16,12 +20,15 @@ pkg.edit.default <- function(old.Package, new.Package, sha, new.pkg.path){
     paste0("Package:\\s+", old.Package),
     paste("Package:", new.Package))
   Package_ <- gsub(".", "_", old.Package, fixed=TRUE)
-  R_init_pkg <- paste0("R_init_", Package_)
   new.Package_ <- paste0(Package_, "_", sha)
   pkg_find_replace(
     file.path("src", "RcppExports.cpp"),
-    R_init_pkg,
+    paste0("R_init_", Package_),
     paste0("R_init_", new.Package_))
+  pkg_find_replace(
+    file.path("R", "RcppExports.R"),
+    sprintf("PACKAGE = '%s'", old.Package),
+    sprintf("PACKAGE = '%s'", new.Package))
   pkg_find_replace(
     "NAMESPACE",
     sprintf('useDynLib\\("?%s"?', Package_),

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -39,7 +39,7 @@ atime_versions(
   \item{verbose}{logical, print messages after every data size?}
   \item{pkg.edit.fun}{function called to edit package before
     installation, should typically replace instances of PKG with
-    PKG.SHA, default works with Rcpp packages that have useDynLib(pkg)
+    PKG.SHA, default works with Rcpp packages that have \code{useDynLib(pkg)}
     in NAMESPACE (no \code{.registration=TRUE}).}
   \item{result}{logical or function, passed to \code{\link{atime}}.}
   \item{N.env.parent}{environment to use as parent of environment

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -39,7 +39,8 @@ atime_versions(
   \item{verbose}{logical, print messages after every data size?}
   \item{pkg.edit.fun}{function called to edit package before
     installation, should typically replace instances of PKG with
-    PKG.SHA, default works with Rcpp packages.}
+    PKG.SHA, default works with Rcpp packages that have useDynLib(pkg)
+    in NAMESPACE (no \code{.registration=TRUE}).}
   \item{result}{logical or function, passed to \code{\link{atime}}.}
   \item{N.env.parent}{environment to use as parent of environment
   created for each data size N, or NULL to use default parent env.}

--- a/man/atime_versions.Rd
+++ b/man/atime_versions.Rd
@@ -38,8 +38,9 @@ atime_versions(
     this many seconds, then no timings for larger N are computed.}
   \item{verbose}{logical, print messages after every data size?}
   \item{pkg.edit.fun}{function called to edit package before
-    installation, should typically replace instances of PKG with
-    PKG.SHA, default works with Rcpp packages that have \code{useDynLib(pkg)}
+    installation, should typically replace instances of \code{PKG} with
+    \code{PKG.SHA},
+    default works with Rcpp packages that have \code{useDynLib(pkg)}
     in NAMESPACE (no \code{.registration=TRUE}).}
   \item{result}{logical or function, passed to \code{\link{atime}}.}
   \item{N.env.parent}{environment to use as parent of environment


### PR DESCRIPTION
current error is
```r
> plist <- atime::atime_pkg(tdir, ".ci")
Checked out 68 of 68 commits... done!
* installing *source* package 'binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4' ...
** this is package 'binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4' version '2023.10.24'
** using staged installation
** libs
using C++ compiler: 'G__~1.EXE (GCC) 14.2.0'
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c PiecewiseFunction.cpp -o PiecewiseFunction.o
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c binseg.cpp -o binseg.o
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c cum_median.cpp -o cum_median.o
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c depth_first.cpp -o depth_first.o
g++ -std=gnu++20  -I"c:/PROGRA~1/R/R-46~1.0/include" -DNDEBUG  -I'C:/Users/hoct2726/AppData/Local/R/win-library/4.6/Rcpp/include'   -I"C:/rtools45/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c interface.cpp -o interface.o
g++ -std=gnu++20 -shared -s -static-libgcc -o binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4.dll tmp.def PiecewiseFunction.o RcppExports.o binseg.o cum_median.o depth_first.o interface.o -LC:/rtools45/x86_64-w64-mingw32.static.posix/lib/x64 -LC:/rtools45/x86_64-w64-mingw32.static.posix/lib -Lc:/PROGRA~1/R/R-46~1.0/bin/x64 -lR
installing to C:/Users/hoct2726/AppData/Local/R/win-library/4.6/00LOCK-binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4/00new/binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4/libs/x64
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4)
Registered S3 methods overwritten by 'binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4':
  method                 from                                               
  print.binsegRcpp       binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  print.binseg_normal_cv binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  coef.binsegRcpp        binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  coef.binseg_normal_cv  binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  plot.binsegRcpp        binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  plot.binseg_normal_cv  binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
  plot.complexity        binsegRcpp.1665b15ab93925f5891ae00d50951fdd68e12346
Error in .Call("_binsegRcpp_max_segs_interface", PACKAGE = "binsegRcpp",  : 
  "_binsegRcpp_max_segs_interface" not available for .Call() for package "binsegRcpp"
In addition: Warning message:
In atime_pkg_test_info(pkg.path, tests.dir) :
  CRAN version=2025.5.13 but installed version=2023.10.24 fix via install.packages('binsegRcpp')
Timing stopped at: 0.01 0 0.01
> traceback()
10: binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4:::max_segs_interface(N)
9: eval(mc.args$setup, N.env)
8: eval(mc.args$setup, N.env)
7: (function (N = default_N(), setup, expr.list = NULL, times = 10, 
       seconds.limit = 0.01, verbose = FALSE, result = FALSE, N.env.parent = NULL, 
       ...) 
   {
       kilobytes <- mem_alloc <- . <- sizes <- expr.name <- NULL
       formal.names <- names(formals())
       mc.args <- as.list(match.call()[-1])
       dots.list <- mc.args[!names(mc.args) %in% formal.names]
       if (!missing(expr.list) && !is.list(expr.list)) {
           stop(domain = NA, gettextf("expr.list should be a list of expressions to run for various N, but has classes %s", 
               paste(class(expr.list), collapse = ", ")))
       }
       elist <- c(expr.list, dots.list)
       result <- check_atime_inputs(N, result, elist)
       if (is.null(N.env.parent)) {
           N.env.parent <- parent.frame()
       }
       done.vec <- structure(rep(FALSE, length(elist)), names = names(elist))
       metric.dt.list <- list()
       for (N.value in N) {
           not.done.yet <- names(done.vec)[!done.vec]
           if (length(not.done.yet) == 0) 
               break
           N.env <- new.env(parent = N.env.parent)
           N.env$N <- N.value
           eval(mc.args$setup, N.env)
           N.df <- run_bench_mark(times, elist[not.done.yet], N.env, 
               result)
           result.row.list <- get_result_rows(N.env$result.list)
           N.stats <- data.table(N = N.value, expr.name = not.done.yet, 
               N.df)[, `:=`(kilobytes = as.numeric(mem_alloc)/1024, 
               memory = NULL, mem_alloc = NULL, total_time = NULL, 
               expression = NULL)][]
           summary.funs <- list(median = median, min = min, q25 = function(x) quantile(x, 
               0.25), q75 = function(x) quantile(x, 0.75), max = max, 
               mean = mean, sd = sd)
           for (fun.name in names(summary.funs)) {
               N.stats[[fun.name]] <- sapply(N.df[["time"]], summary.funs[[fun.name]])
           }
           done.pkgs <- N.stats[median > seconds.limit, paste(expr.name)]
           done.vec[done.pkgs] <- TRUE
           new.bad <- intersect(names(result.row.list$result.rows), 
               names(N.stats))
           if (length(new.bad)) {
               stop(sprintf("value of expression is 1 row data frame with column(s) named %s (reserved for internal use); please fix by changing the column name(s) in your results", 
                   paste(new.bad, collapse = ", ")))
           }
           N.out <- data.table(N.stats, result.row.list$result.rows)
           if (verbose) 
               print(N.out[, data.table(N, expr.name, seconds.median = median, 
                   kilobytes)], class = FALSE)
           metric.dt.list[[paste(N.value)]] <- N.out
       }
       unit.col.vec <- c("kilobytes", seconds = "median", result.row.list$more.units)
       measurements <- rbindlist(metric.dt.list)
       expr.list.params <- attr(expr.list, "parameters")
       by.vec <- "expr.name"
       if (is.data.table(expr.list.params)) {
           measurements <- expr.list.params[measurements, on = "expr.name"]
           by.vec <- names(expr.list.params)
       }
       only.one <- measurements[, .(sizes = .N), by = expr.name][sizes == 
           1]
       if (nrow(only.one)) {
           warning("please increase max N or seconds.limit, because only one N was evaluated for expr.name: ", 
               paste(only.one[["expr.name"]], collapse = ", "))
       }
       structure(list(unit.col.vec = unit.col.vec, seconds.limit = seconds.limit, 
           measurements = measurements, by.vec = by.vec), class = "atime")
   })(c(4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 
   16384, 32768, 65536, 131072, 262144, 524288, 1048576), {
       max.segs <- binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4:::max_segs_interface(N)
       data.vec <- 1:N
   }, structure(list(`HEAD=test-setup-HEAD` = binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4::binseg("l1", 
       data.vec, max.segs), `installed=2023.10.24` = binsegRcpp::binseg("l1", 
       data.vec, max.segs), `base=master` = binsegRcpp.9b0047197474c5224fa4de838044a8d9020d1a66::binseg("l1", 
       data.vec, max.segs), `merge-base` = binsegRcpp.7e9bc765f57084d0313297726b3cfba12ce7a718::binseg("l1", 
       data.vec, max.segs)), Package = c(Package = "binsegRcpp"), new.Package = "binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4"), 
       10, 0.01, FALSE, FALSE, <environment>)
6: do.call(atime, a.args)
5: system.time({
       out.list <- do.call(atime, a.args)
   })
4: atime::atime_versions(N.env.parent = <environment>, pkg.path = "C:\\Users\\hoct2726\\AppData\\Local\\Temp\\Rtmp4gmGcw\\file5bc676c6bb3", 
       sha.vec = list(`HEAD=test-setup-HEAD` = "9c84bf5e2c9c448f63630b5c15c29d45b42d25d4", 
           `installed=2023.10.24` = "", `base=master` = "9b0047197474c5224fa4de838044a8d9020d1a66", 
           `merge-base` = "7e9bc765f57084d0313297726b3cfba12ce7a718"), 
       N = c(4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 
       8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576
       ), setup = {
           max.segs <- binsegRcpp:::max_segs_interface(N)
           data.vec <- 1:N
       }, expr = binsegRcpp::binseg("l1", data.vec, max.segs))
3: eval(atv.call, test.info)
2: eval(atv.call, test.info)
1: atime::atime_pkg(tdir, ".ci")
```

we see `binsegRcpp.9c84bf5e2c9c448f63630b5c15c29d45b42d25d4:::max_segs_interface(N)` gives `"_binsegRcpp_max_segs_interface" not available for .Call() for package "binsegRcpp"` so we need to add an entry to pkg.edit.fun.