### PR TITLE
support N with different units

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Changes in version 2026.5.29
 - atime_pkg() now uses only a common subset of columns of the measurements table from each test, so that each test can have different units to analyze.
 - atime_versions() runs setup using the HEAD commit (if present).
 - atime_versions() bugfix for Rcpp packages, which must useDynLib(pkg) in NAMESPACE without .registration=TRUE, so we can edit PACKAGE args in R/RcppExports.R.
+- atime() now allows different column names in 1-row result data frames, either in different expressions, or different N.
 
 Changes in version 2026.4.2
 

--- a/R/atime.R
+++ b/R/atime.R
@@ -3,22 +3,19 @@ default_N <- function(){
 }
 
 get_result_rows <- function(result.list){
-  if(
-    all(sapply(result.list, is.data.frame)) &&
-      all(sapply(result.list, nrow)==1)
-  ){
-    names.list <- lapply(result.list, names)
-    for(result.i in seq_along(names.list)){
-      if(!identical(names.list[[1]], names.list[[result.i]])){
-        stop(sprintf("results are all 1 row data frames, but some have different names (%s, %s); please fix by making column names of results identical", names(names.list)[[1]], names(names.list)[[result.i]]))
-      }
+  out.rows <- list()
+  out.names <- list()
+  for(result.i in seq_along(result.list)){
+    result <- result.list[[result.i]]
+    if(is.data.frame(result) && nrow(result)==1){
+      is.num <- sapply(result, is.numeric)
+      out.rows[[paste(result.i)]] <- result
+      out.names[[paste(result.i)]] <- names(result)[is.num]
     }
-    result.rows <- do.call(rbind, result.list)
-    is.more <- sapply(result.rows, is.numeric)
-    list(
-      result.rows=result.rows,
-      more.units=names(result.rows)[is.more])
   }
+  list(
+    result.rows=rbindlist(out.rows, use.names=TRUE, fill=TRUE),
+    more.units=unique(unlist(out.names)))
 }
 
 run_bench_mark <- function(times, sub.elist, N.env, result){
@@ -131,7 +128,7 @@ atime <- function(N=default_N(), setup, expr.list=NULL, times=10, seconds.limit=
     "kilobytes",
     seconds="median",
     result.row.list$more.units)
-  measurements <- rbindlist(metric.dt.list)
+  measurements <- rbindlist(metric.dt.list, use.names=TRUE, fill=TRUE)
   expr.list.params <- attr(expr.list,"parameters")
   by.vec <- "expr.name"
   if(is.data.table(expr.list.params)){

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -131,6 +131,17 @@ test_that("result returned when some are NULL and others not", {
   expect_is(atime.list$mea$result, "list")
 })
 
+test_that("N with different units", {
+  atime.list <- atime::atime(
+    slow=if(N==2){
+      data.frame(x=1)
+    }else if(N==4){
+      data.frame(y=2)
+    }else data.frame(x=3, y=4),
+    result = TRUE)
+  expect_is(atime.list$mea$result, "list")
+})
+
 test_that("sensible error when duplicate names", {
   expect_error({
     atime::atime(

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -139,7 +139,9 @@ test_that("N with different units", {
       data.frame(y=2)
     }else data.frame(x=3, y=4),
     result = TRUE)
-  expect_is(atime.list$mea$result, "list")
+  expected.dt <- data.table(x=c(1,NA,3), y=c(NA,2,4))
+  computed.dt <- atime.list$mea[1:3, .(x,y)]
+  expect_equal(computed.dt, expected.dt)
 })
 
 test_that("sensible error when duplicate names", {
@@ -438,31 +440,18 @@ if(requireNamespace("ggplot2"))test_that("references for non-NA unit, with NA un
 })
 
 test_that("error for result data frames with different column names",{
-  expect_error({
-    atime::atime(
-      missing=data.frame(my_unit=NA),
-      constant=data.frame(foo=1),
-      linear=data.frame(my_unit=N),
-      quadratic=data.frame(my_unit=N^2),
-      seconds.limit=0.001,
-      result=TRUE)
-  }, "results are all 1 row data frames, but some have different names (missing, constant); please fix by making column names of results identical", fixed=TRUE)
-  expect_error({
-    atime:::get_result_rows(list(
-      missing=data.frame(my_unit=NA),
-      linear=data.frame(my_unit=5),
-      quadratic=data.frame(my_unit=1, other=2)))
-  }, "results are all 1 row data frames, but some have different names (missing, quadratic); please fix by making column names of results identical", fixed=TRUE)
-  expect_null(
-    atime:::get_result_rows(list(
-      missing=data.frame(my_unit=NA),
-      linear=data.frame(my_unit=5),
-      quadratic=data.frame(my_unit=1, other=2:3)))
-  )
+  alist <- atime::atime(
+    missing=data.frame(my_unit=NA),
+    constant=data.frame(foo=1),
+    linear=data.frame(my_unit=N),
+    quadratic=data.frame(my_unit=N^2),
+    seconds.limit=0.001,
+    result=TRUE)
+  expect_in(c("my_unit", "foo"), names(alist$measurements))
   valid.input.list <- list(
-    missing=data.frame(my_unit=NA, other="a"),
-    linear=data.frame(my_unit=5, other="b"),
-    quadratic=data.frame(my_unit=1, other="c"))
+    missing=data.table(my_unit=NA, other="a"),
+    linear=data.table(my_unit=5, other="b"),
+    quadratic=data.table(my_unit=1, other="c"))
   computed <- atime:::get_result_rows(valid.input.list)
   expected <- list(
     result.rows=do.call(rbind, valid.input.list),


### PR DESCRIPTION
fix for https://github.com/poncateam/poncatime/pull/21
```
$`2`… 
[15] "max"       "mean"      "sd"        "x"        

$`4`…
[15] "max"       "mean"      "sd"        "y"        

$`8`…
[15] "max"       "mean"      "sd"        "x"         "y"        

── Error: N with different units ───────────────────────────────────────────────────────
Error in `rbindlist(metric.dt.list)`: Item 3 has 19 columns, inconsistent with item 1 which has 18 columns. To fill missing columns use fill=TRUE.
Backtrace:
    ▆
 1. └─atime::atime(...) at tests/testthat/test-CRAN.R:135:3
 2.   └─data.table::rbindlist(metric.dt.list)
```