### PR TITLE
fix: versioned installs rewrite build-stage Rd Sexpr package references

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ Changes in version 2026.5.29
 - atime_pkg() now uses only a common subset of columns of the measurements table from each test, so that each test can have different units to analyze.
 - atime_pkg() and atime_pkg_test_info() gain verbose arg.
 - glob_find_replace() gains warn arg, to warn if there were no replacements made.
+- glob_find_replace() gains fixed arg, for literal string replacement.
+- pkg.edit.default() rewrites PKG:: references in man/*.Rd during versioned installs, so build-stage \\Sexpr calls resolve to PKG.SHA (fixes animint/animint2#340).
 - atime_versions() runs setup using the HEAD commit (if present).
 - atime_versions() bugfix for Rcpp packages that useDynLib(pkg) in NAMESPACE (without registration), new editing of PACKAGE args in R/RcppExports.R.
 - atime() now allows different column names in 1-row result data frames, either in different expressions, or different N.

--- a/R/versions.R
+++ b/R/versions.R
@@ -1,8 +1,8 @@
-glob_find_replace <- function(glob, FIND, REPLACE, warn=TRUE){
+glob_find_replace <- function(glob, FIND, REPLACE, warn=TRUE, fixed=FALSE){
   some.files <- Sys.glob(glob)
   for(f in some.files){
     l.old <- readLines(f)
-    l.new <- gsub(FIND, REPLACE, l.old)
+    l.new <- gsub(FIND, REPLACE, l.old, fixed=fixed)
     if(identical(l.old, l.new)){
       if(warn)warning(sprintf(
         "no changes to %s when FIND=%s and replace=%s",
@@ -14,8 +14,9 @@ glob_find_replace <- function(glob, FIND, REPLACE, warn=TRUE){
 }
 
 pkg.edit.default <- function(old.Package, new.Package, sha, new.pkg.path){
-  pkg_find_replace <- function(glob, FIND, REPLACE, warn=TRUE){
-    glob_find_replace(file.path(new.pkg.path, glob), FIND, REPLACE, warn)
+  pkg_find_replace <- function(glob, FIND, REPLACE, warn=TRUE, fixed=FALSE){
+    glob_find_replace(
+      file.path(new.pkg.path, glob), FIND, REPLACE, warn, fixed)
   }
   pkg_find_replace(
     "DESCRIPTION", 
@@ -36,6 +37,12 @@ pkg.edit.default <- function(old.Package, new.Package, sha, new.pkg.path){
     "NAMESPACE",
     sprintf('useDynLib\\("?%s"?', Package_),
     paste0('useDynLib(', new.Package))
+  pkg_find_replace(
+    file.path("man", "*.Rd"),
+    paste0(old.Package, "::"),
+    paste0(new.Package, "::"),
+    fixed=TRUE,
+    warn=FALSE)
 }
 
 atime_versions_remove <- function(Package){

--- a/man/glob_find_replace.Rd
+++ b/man/glob_find_replace.Rd
@@ -2,12 +2,16 @@
 \alias{glob_find_replace}
 \title{Find and replace within files}
 \description{Find and replace for every file specified by glob.}
-\usage{glob_find_replace(glob, FIND, REPLACE, warn=TRUE)}
+\usage{glob_find_replace(glob, FIND, REPLACE, warn=TRUE, fixed=FALSE)}
 \arguments{
   \item{glob}{character string: glob defining files.}
-  \item{FIND}{character string: regex to find.}
-  \item{REPLACE}{character string: regex to use for replacement.}
+  \item{FIND}{character string: pattern to find (regex unless
+    \code{fixed=TRUE}).}
+  \item{REPLACE}{character string: replacement (regex unless
+    \code{fixed=TRUE}).}
   \item{warn}{logical (default \code{TRUE}): warn if nothing replaced.}
+  \item{fixed}{logical (default \code{FALSE}): treat \code{FIND} and
+    \code{REPLACE} as literal strings?}
 }
 \value{nothing.}
 

--- a/tests/testthat/test-versioned-rd-sexpr.R
+++ b/tests/testthat/test-versioned-rd-sexpr.R
@@ -1,0 +1,92 @@
+library(testthat)
+
+write_rd_sexpr_pkg <- function(pkg.path, rd_helper_body, use_sexpr=FALSE){
+  dir.create(file.path(pkg.path, "R"), recursive=TRUE)
+  dir.create(file.path(pkg.path, "man"), recursive=TRUE)
+  writeLines(c(
+    "Package: rd.pkg",
+    "Title: Rd Sexpr regression package",
+    "Version: 1.0.0",
+    "Description: Test package for versioned Rd Sexpr installs.",
+    "License: GPL-3"
+  ), file.path(pkg.path, "DESCRIPTION"))
+  writeLines(c(
+    "export(my_fun)",
+    "export(rd_helper)"
+  ), file.path(pkg.path, "NAMESPACE"))
+  writeLines(c(
+    "my_fun <- function(x) x + 1",
+    paste0("rd_helper <- function() ", rd_helper_body)
+  ), file.path(pkg.path, "R", "functions.R"))
+  details_lines <- if(use_sexpr){
+    c(
+      "\\details{",
+      "  \\Sexpr[results=rd,stage=build]{rd.pkg:::rd_helper()}",
+      "}")
+  }else{
+    "\\details{No build-stage Sexpr.}"
+  }
+  writeLines(c(
+    "\\name{my_fun}",
+    "\\alias{my_fun}",
+    "\\title{Test Function}",
+    "\\description{Uses build-stage Sexpr.}",
+    "\\usage{my_fun(x)}",
+    "\\arguments{\\item{x}{Numeric value.}}",
+    details_lines,
+    "\\value{Input plus one.}"
+  ), file.path(pkg.path, "man", "my_fun.Rd"))
+}
+
+test_that("versioned install rewrites build-stage Rd package references", {
+  tdir <- tempfile()
+  dir.create(tdir)
+  old.lib <- .libPaths()
+  new.lib <- file.path(tdir, "library")
+  dir.create(new.lib)
+  .libPaths(c(new.lib, old.lib))
+  on.exit({
+    for(pkg in rev(grep("^rd\\.pkg($|\\.)", loadedNamespaces(), value=TRUE))){
+      try(unloadNamespace(pkg), silent=TRUE)
+    }
+    .libPaths(old.lib)
+    unlink(tdir, recursive=TRUE, force=TRUE)
+  }, add=TRUE)
+  current.path <- file.path(tdir, "current")
+  write_rd_sexpr_pkg(current.path, 'stop("wrong package version")')
+  R.bin <- file.path(R.home("bin"), "R")
+  install.status <- system2(
+    R.bin,
+    c("CMD", "INSTALL", "-l", shQuote(new.lib), shQuote(current.path)),
+    stdout=FALSE, stderr=FALSE)
+  expect_equal(install.status, 0)
+  expect_error(
+    get("rd_helper", envir=asNamespace("rd.pkg"))(),
+    "wrong package version",
+    fixed=TRUE)
+  pkg.path <- file.path(tdir, "rdpkg")
+  write_rd_sexpr_pkg(pkg.path, '"\\\\code{historical}"', use_sexpr=TRUE)
+  git2r::init(pkg.path)
+  repo <- git2r::repository(pkg.path)
+  git2r::add(repo, c("DESCRIPTION", "NAMESPACE", "R/functions.R", "man/my_fun.Rd"))
+  if(is.null(git2r::default_signature(repo))){
+    git2r::config(repo, user.name="test", user.email="test@test.com")
+  }
+  git2r::commit(repo, "historical commit")
+  sha <- git2r::revparse_single(repo, "HEAD")$sha
+  result <- NULL
+  expect_no_error({
+    result <- atime::atime_versions(
+      pkg.path=pkg.path,
+      N=c(1, 2),
+      setup={x <- N},
+      expr=rd.pkg::my_fun(x),
+      test.sha=sha,
+      times=1,
+      seconds.limit=1)
+  })
+  expect_s3_class(result, "atime")
+  installed <- list.dirs(new.lib, full.names=FALSE, recursive=FALSE)
+  versioned.package <- sprintf("rd.pkg.%s", sha)
+  expect_length(installed[installed == versioned.package], 1)
+})


### PR DESCRIPTION

Related: [animint/animint2#340](https://github.com/animint/animint2/issues/340)

## Problem

`atime_versions()` installs old commits as `PKG.SHA`, but `pkg.edit.default()` does not rewrite `PKG::` / `PKG:::` in `man/*.Rd`. Build-stage `\Sexpr` calls therefore resolve to an already-installed current `PKG` instead of the historical `PKG.SHA`.

This breaks animint2 CI ([animint/animint2#340](https://github.com/animint/animint2/issues/340)): the atime job fails at baseline install with `Error: No geom called GeomDotplot`, before the PR code is tested.

## Approach

1. **Commit 1:** add a self-contained regression test that fails on current `main`.
2. **Commit 2:** fix `pkg.edit.default()` to rewrite `PKG::` → `PKG.SHA::` in `man/*.Rd` (with `fixed=TRUE` for dotted package names like `data.table`).

The test reproduces the failure without depending on animint2 or the network:

- install a current `rd.pkg` whose helper throws `"wrong package version"`;
- create a historical git version with `\Sexpr{rd.pkg:::rd_helper()}` in its `.Rd` file;
- run `atime_versions()` and expect the renamed historical package to install.

On `main`, the test fails because the `.Rd` `\Sexpr` still reaches the installed current package. After the fix, the same test passes.

## Expected result

- CI shows a red X after commit 1 (test correctly fails).
- CI turns green after commit 2.
- animint2 atime jobs can install historical baselines without `\Sexpr` resolving to the wrong package namespace.

## Verification test ran locally 
<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/05b72a3d-d75d-4e4a-bbf8-51617ed03f28" />
----
<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/94327870-6d78-42b1-a6f2-4d72f02816da" />

